### PR TITLE
Remove get_current_devices as it's not used in this cookbook and it's av...

### DIFF
--- a/libraries/provider_rightscale_backup.rb
+++ b/libraries/provider_rightscale_backup.rb
@@ -226,28 +226,6 @@ class Chef
         backup.first
       end
 
-      # Gets all supported devices from /proc/partitions.
-      #
-      # @return [Array<String>] the devices list.
-      #
-      def get_current_devices
-        # Read devices that are currently in use from the last column in /proc/partitions
-        partitions = IO.readlines("/proc/partitions").drop(2).map { |line| line.chomp.split.last }
-
-        # Eliminate all LVM partitions
-        partitions = partitions.reject { |partition| partition =~ /^dm-\d/ }
-
-        # Get all the devices in the form of sda, xvda, hda, etc.
-        devices = partitions.select { |partition| partition =~ /[a-z]$/ }.sort.map { |device| "/dev/#{device}" }
-
-        # If no devices found in those forms, check for devices in the form of sda1, xvda1, hda1, etc.
-        if devices.empty?
-          devices = partitions.select { |partition| partition =~ /[0-9]$/ }.sort.map { |device| "/dev/#{device}" }
-        end
-
-        devices
-      end
-
       # Gets the href of the cloud.
       #
       # @return [String] the cloud href

--- a/spec/unit_test/provider_rightscale_backup_spec.rb
+++ b/spec/unit_test/provider_rightscale_backup_spec.rb
@@ -402,31 +402,5 @@ describe Chef::Provider::RightscaleBackup do
       end
     end
 
-    describe "#get_current_devices" do
-      let(:devices) do
-        proc_partitions = [
-          'major minor  #blocks  name',
-          '',
-          '1        0  123456789 xvda',
-          '1        1     123456 xvda1',
-          '2        0    1234567 dm-0',
-          '3        0    1234567 dm-1'
-        ]
-        IO.stub(:readlines).and_return(proc_partitions)
-        provider.send(:get_current_devices)
-      end
-
-      it "should return at least one partition" do
-        devices.should have_at_least(1).items
-      end
-
-      it "should not list LVM partitions" do
-        devices.select { |item| item =~ /dm-\d/ }.should be_empty
-      end
-
-      it "should return items with '/dev' string prefix" do
-        devices.reject { |item| item =~ /^\/dev/ }.should be_empty
-      end
-    end
   end
 end


### PR DESCRIPTION
...ailable in rightscale_volume cookbook if needed.
