### PR TITLE
pinning right_api_client

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,7 @@ site :opscode
 
 metadata
 
-cookbook 'build-essential'
+cookbook 'build-essential', '~> 3.2.0'
 cookbook 'rightscale_volume', github:'rightscale-cookbooks/rightscale_volume'
 
 group :integration do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ rightscale_backup Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the rightscale_backup cookbook.
 
+v1.2.1
+------
+- Pin right_api_client at v1.6.1 for ruby 1.9.3 support, Chef 11
+
 v1.1.8
 ------
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'berkshelf'
 gem 'thor-foodcritic'
-gem 'rightscale_upload', :github => 'rightscale/rightscale_upload'
 
 group :integration do
   gem 'strainer', '~> 3.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,8 @@ group :integration do
   gem 'chefspec', '~> 3.4.0'
   gem 'rspec', '~> 2.14.1'
   gem 'travis-lint'
+  gem 'buff-ignore','1.1.1'
+  gem 'rack', '1.6.4'
+  gem 'json','~> 1.8.0'
+  gem 'net-http-persistent', '= 2.9.4'
 end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Github Repository: [https://github.com/rightscale-cookbooks/rightscale_backup](h
 
 * The system being configured must be a RightScale managed VM to have the
 required access to the RightScale API.
-* Chef 11 or higher.
+* Chef 11.
 * [RightLink 10](http://docs.rightscale.com/rl10/) See cookbook version 1.1.8 for RightLink 6 support
 * Requires a RightScale account that is registered with all the cloud vendors
 you expect to provision on (e.g. AWS, Rackspace, Openstack, CloudStack, GCE,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Provides a resource to manage volume backups on any cloud RightScale supports.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '1.2.1'
 
-depends 'build-essential'
-depends 'rightscale_volume', '~> 1.3.0'
+depends 'build-essential', '3.2.0'
+depends 'rightscale_volume', '~> 1.3.1'
 
 recipe 'rightscale_backup::default', 'Default recipe for installing required packages/gems.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,13 +3,13 @@
 # Recipe:: default
 #
 # Copyright (C) 2014 RightScale, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,4 +25,7 @@ include_recipe 'build-essential'
 
 # Install gems during compile phase so that they are available to files
 # which require them during converge phase.
-chef_gem 'right_api_client'
+# pin gem for ruby 1.9/chef 11 compatiblity
+chef_gem 'right_api_client' do
+  version "1.6.1"
+end


### PR DESCRIPTION
chef 11 only supports ruby 1.9.3 and right_api_client now only support ruby => 2.0.
pinning right_api_client at 1.6.1 until chef 12 is supported.
pinning other gems for ruby 1.9 compatiblity